### PR TITLE
Fix aggregation queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,9 @@ SELECT LastName, FirstName FROM Employee WHERE City = "Calgary";
 <summary> <code> #2 </code> </summary>
 
 ```sql
-SELECT FirstName, LastName, Min(BirthDate) FROM Employee;
+SELECT FirstName, LastName, BirthDate FROM Employee
+ORDER BY BirthDate
+LIMIT 1;
 ```
 
 </details>
@@ -369,7 +371,9 @@ SELECT FirstName, LastName, Min(BirthDate) FROM Employee;
 <summary> <code> #3 </code> </summary>
 
 ```sql
-SELECT FirstName, LastName, Max(BirthDate) FROM Employee;
+SELECT FirstName, LastName, BirthDate FROM Employee
+ORDER BY BirthDate DESC
+LIMIT 1;
 ```
 
 </details>


### PR DESCRIPTION
Selecting non-aggregate columns while doing an aggregate is undefined behavior. For example `SELECT Name, avg(Milliseconds) FROM Track`, the returned name is meaningless. Postgres will reject the query, but SQLite oddly doesn't validate it. This updates the birthdate queries to use `ORDER BY` and `LIMIT` instead.